### PR TITLE
added code to suppress low voltage warnings

### DIFF
--- a/rpi/config.txt
+++ b/rpi/config.txt
@@ -78,3 +78,4 @@ otg_mode=1
 arm_boost=1
 
 [all]
+avoid_warnings=1


### PR DESCRIPTION
In unfavorable conditions, a low voltage warning would be displayed on the Remote Control Devices. This code change fixes that issue by suppressing these kinds of messages all together